### PR TITLE
Override Terraform version when using tfenv 2+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN curl "https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.z
     mv packer /usr/local/bin && \
     chmod a+x /usr/local/bin/packer
 
-RUN git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+RUN git clone -b v2.0.0-beta1 https://github.com/tfutils/tfenv.git ~/.tfenv
 RUN echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile && ln -s ~/.tfenv/bin/* /usr/local/bin
 RUN tfenv install 0.12.9
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,9 +19,9 @@ ssh-keyscan github.com >> /root/.ssh/known_hosts
 
 # Allow terraform version override
 if [[ ! -z "$INPUT_TERRAFORM_VERSION" ]]; then
-  echo "terraform_version overried set to $INPUT_TERRAFORM_VERSION"
+  echo "terraform_version override set to $INPUT_TERRAFORM_VERSION"
+  echo "$INPUT_TERRAFORM_VERSION" > .terraform-version
   tfenv install "$INPUT_TERRAFORM_VERSION"
-  tfenv use "$INPUT_TERRAFORM_VERSION"
 else
   # Make sure we have the correct terraform version, if we have a .terraform-version file
   tfenv install || true


### PR DESCRIPTION
The newest tfenv versions (currently 2.0.0-beta1) no longer change
version when using `tfenv use` to set a global default if a
.terraform-version is in the current directory and instead stay with the
project version.

This changes the version specified in `.terraform-version` to ensure
tfenv switches versions.