### PR TITLE
Golang Update Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:buster
+FROM golang:1.16-buster
+
+# As of v1.16 module-aware mode is enabled by default, regardless of whether a go.mod file is present in the current working directory or a parent directory.
+# More precisely, the GO111MODULE environment variable now defaults to on.
+ENV GO111MODULE auto
 
 RUN apt-get update && apt-get --no-install-recommends -y install \
     git \


### PR DESCRIPTION
Since the 1.16 release Terratest is failing to run for our packages:
```
Starting tests
go: cannot find main module, but found Gopkg.lock in /go/src/github.com/fac/workspace/test
	to create a module there, run:
	go mod init
```

This [update](https://golang.org/doc/go1.16) changes the behaviour of module-aware mode:

> Module-aware mode is enabled by default, regardless of whether a go.mod file is present in the current working directory or a parent directory. More precisely, the GO111MODULE environment variable now defaults to on. To switch to the previous behavior, set GO111MODULE to auto. 

Tested: https://github.com/fac/package-aws-monitoring/pull/55/checks ✅ 