### PR TITLE
Use terraform 0.12.30 for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl "https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.z
 
 RUN git clone -b v2.0.0-beta1 https://github.com/tfutils/tfenv.git ~/.tfenv
 RUN echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile && ln -s ~/.tfenv/bin/* /usr/local/bin
-RUN tfenv install 0.12.9
+RUN tfenv install 0.12.30
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
We are running at least this version everywhere and a number of 3rd
party modules only support terraform >= 0.12.26

