### PR TITLE
Add entrypoint.sh logic to allow go.mod

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,15 +27,21 @@ else
   tfenv install || true
 fi
 
-# Setup under GOPATH so dep etc works
-echo "Setting up GOPATH to include $PWD"
-CHECKOUT=$(basename "$PWD")
-mkdir -p $GODIR
-ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
+if [ -f "$PWD/test/go.mod" ]; then
+    echo "Detected go.mod in test directory. Using that for dependencies."
+    cd "$PWD/test"
+    gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128
+else
+    # Setup under GOPATH so dep etc works
+    echo "Setting up GOPATH to include $PWD"
+    CHECKOUT=$(basename "$PWD")
+    mkdir -p $GODIR
+    ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
 
-cd "${GODIR}/${CHECKOUT}/test"
-echo "Running go dep"
-dep ensure
+    cd "${GODIR}/${CHECKOUT}/test"
+    echo "Running go dep"
+    dep ensure
+fi
 
 echo "Starting tests"
 gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,6 @@ fi
 if [ -f "$PWD/test/go.mod" ]; then
     echo "Detected go.mod in test directory. Using that for dependencies."
     cd "$PWD/test"
-    gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128
 else
     # Setup under GOPATH so dep etc works
     echo "Setting up GOPATH to include $PWD"


### PR DESCRIPTION
This will check if `test/go.mod` exists in the repo and will use that method to
fetch dependencies, otherwise it'll use dep instead.

Tested on https://github.com/fac/package-systems-manager/pull/11 with latest Terratest (0.38.2)

I'm planning to bump the release a minor version (to 1.4.0), although I guess technically it's a change in behaviour (if you have a Gopkg.lock and go.sum with different versions for some reason). We've had bigger changes in minor releases (different default TF version), and can then go to v2 when we drop `go dep` support.