### PR TITLE
Merge go.mod support to 1.x-stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl "https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.z
 
 RUN git clone -b v2.0.0-beta1 https://github.com/tfutils/tfenv.git ~/.tfenv
 RUN echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile && ln -s ~/.tfenv/bin/* /usr/local/bin
-RUN tfenv install 0.12.30
+RUN tfenv install 0.13.7
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,19 @@ ENV GO111MODULE auto
 RUN apt-get update && apt-get --no-install-recommends -y install \
     git \
     unzip \
-    python-pip \
+    python3 \
+    python3-setuptools \
+    python3-pip \
+    python3-venv \
     go-dep ;
 
 # Install gotestsum for parsing test output
-RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.4.0/gotestsum_0.4.0_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum
+RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum
 
 # Install awscli
 RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws;
+    python3 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws;
 
 # Install packer
 RUN curl "https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip" -o "packer.zip" && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,15 +27,20 @@ else
   tfenv install || true
 fi
 
-# Setup under GOPATH so dep etc works
-echo "Setting up GOPATH to include $PWD"
-CHECKOUT=$(basename "$PWD")
-mkdir -p $GODIR
-ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
+if [ -f "$PWD/test/go.mod" ]; then
+    echo "Detected go.mod in test directory. Using that for dependencies."
+    cd "$PWD/test"
+else
+    # Setup under GOPATH so dep etc works
+    echo "Setting up GOPATH to include $PWD"
+    CHECKOUT=$(basename "$PWD")
+    mkdir -p $GODIR
+    ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
 
-cd "${GODIR}/${CHECKOUT}/test"
-echo "Running go dep"
-dep ensure
+    cd "${GODIR}/${CHECKOUT}/test"
+    echo "Running go dep"
+    dep ensure
+fi
 
 echo "Starting tests"
 gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128


### PR DESCRIPTION
This releases #9 to the stable branch of the action. Will tag as 1.4.0.