### PR TITLE
Upgrade golang version on base GHA image for running terratest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster
+FROM golang:1.18-buster
 
 # As of v1.16 module-aware mode is enabled by default, regardless of whether a go.mod file is present in the current working directory or a parent directory.
 # More precisely, the GO111MODULE environment variable now defaults to on.


### PR DESCRIPTION
The golang version here had fallen out of pace with the required golang version for running 
automated terratest.
As of the latest terratest upgrade to `v0.41.7`, golang `1.18` is required and with this opportunity
we update it for the base GHA runner container.


Part of https://github.com/fac/platform-issues/issues/2228