### PR TITLE
Feature: Only run tests against changed modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,19 @@
-FROM golang:1.18-buster
-
-# As of v1.16 module-aware mode is enabled by default, regardless of whether a go.mod file is present in the current working directory or a parent directory.
-# More precisely, the GO111MODULE environment variable now defaults to on.
-ENV GO111MODULE auto
+FROM golang:1.19-buster
 
 RUN apt-get update && apt-get --no-install-recommends -y install \
     git \
-    unzip \
-    python3 \
-    python3-setuptools \
-    python3-pip \
-    python3-venv \
-    go-dep ;
+    unzip 
 
 # Install gotestsum for parsing test output
-RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum
+RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.9.0/gotestsum_1.9.0_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum
 
 # Install awscli
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    python3 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws;
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
 
 # Install packer
-RUN curl "https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_linux_amd64.zip" -o "packer.zip" && \
+RUN curl "https://releases.hashicorp.com/packer/1.8.5/packer_1.8.5_linux_amd64.zip" -o "packer.zip" && \
     unzip packer.zip && \
     mv packer /usr/local/bin && \
     chmod a+x /usr/local/bin/packer
@@ -31,9 +22,9 @@ RUN curl "https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_linux_amd64.z
 RUN curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
     dpkg -i session-manager-plugin.deb
 
-RUN git clone -b v2.0.0-beta1 https://github.com/tfutils/tfenv.git ~/.tfenv
+RUN git clone -b v3.0.0 https://github.com/tfutils/tfenv.git ~/.tfenv
 RUN echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile && ln -s ~/.tfenv/bin/* /usr/local/bin
-RUN tfenv install 0.13.7
+RUN tfenv install 1.3.4
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,36 @@ For authentication with AWS you can set the environment variables:
   * **AWS_ACCESS_KEY_ID**
   * **AWS_SECRET_ACCESS_KEY**
 
+You can pass in a list of modified modules from the source to only run those tests.
+```yaml
+name: Terratest
+on: [push]
+
+jobs:
+  test:
+    name: Checkout
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout step
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Grab list of modified modules dynamically using diff against master
+        run: echo "modified_modules=$(git diff origin/master... --name-only examples/ modules/ | awk -F'/' '{print $(NF-1)}'| uniq | tr '\n' ' ')" >> "$GITHUB_ENV"
+
+      - name: Terratest
+        uses: fac/terratest-github-action@feature/only-test-changed-modules
+        with:
+          SSH_PRIV_KEY: ${{ secrets.TF_MODULES_SSH_KEY }}
+          modified_modules: ${{ env.modified_modules }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+
+```
+
 This action typically creates and destroys actual infrastructure and should only be run against dedicated test / sandbox accounts.
 
 ```yaml

--- a/Readme.md
+++ b/Readme.md
@@ -38,15 +38,13 @@ jobs:
         run: echo "modified_modules=$(git diff origin/master... --name-only examples/ modules/ | awk -F'/' '{print $(NF-1)}'| uniq | tr '\n' ' ')" >> "$GITHUB_ENV"
 
       - name: Terratest
-        uses: fac/terratest-github-action@feature/only-test-changed-modules
+        uses: fac/terratest-github-action@2.x-rc
         with:
           SSH_PRIV_KEY: ${{ secrets.TF_MODULES_SSH_KEY }}
           modified_modules: ${{ env.modified_modules }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-
 ```
 
 This action typically creates and destroys actual infrastructure and should only be run against dedicated test / sandbox accounts.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
     required: true
   terraform_version:
     description: "If set override any .terraform-version file in the repo and use this specific version (can be latest)"
+  modified_modules:
+    description: List of module names that have been updated. Used to only run tests for modified modules. If not specified all tests run.
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,45 +2,42 @@
 
 set -eo pipefail
 
-GODIR=/go/src/github.com/fac
-
 # Setup SSH KEY for private repo access
 echo "Setting up SSH key"
 mkdir -p /root/.ssh && chmod 700 /root/.ssh
-echo "${INPUT_SSH_PRIV_KEY}" > /root/.ssh/id_rsa
+echo "${INPUT_SSH_PRIV_KEY}" >/root/.ssh/id_rsa
 unset INPUT_SSH_PRIV_KEY
-
 chmod 600 /root/.ssh/id_rsa
 eval $(ssh-agent -s)
 ssh-add
 
 # Pre-seed host keys for github.com
-ssh-keyscan github.com >> /root/.ssh/known_hosts
+ssh-keyscan github.com >>/root/.ssh/known_hosts
 
 # Allow terraform version override
 if [[ ! -z "$INPUT_TERRAFORM_VERSION" ]]; then
   echo "terraform_version override set to $INPUT_TERRAFORM_VERSION"
-  echo "$INPUT_TERRAFORM_VERSION" > .terraform-version
+  echo "$INPUT_TERRAFORM_VERSION" >.terraform-version
   tfenv install "$INPUT_TERRAFORM_VERSION"
 else
   # Make sure we have the correct terraform version, if we have a .terraform-version file
   tfenv install || true
 fi
 
-if [ -f "$PWD/test/go.mod" ]; then
-    echo "Detected go.mod in test directory. Using that for dependencies."
-    cd "$PWD/test"
+# Install Go Dependicies
+cd "$PWD/test"
+go install
+
+# If we pass in a list of modified modules then only run those tests 
+# otherwise run all tests.
+if [[ ! -z "$modified_modules" ]]; then
+  package_name=`cat go.mod | grep module | awk '{print $2}'`
+  for i in $modified_modules; do
+    TESTS+=$(echo "$package_name/$i ")
+  done
+  echo "Running tests: $TESTS"
+  gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128 $TESTS
 else
-    # Setup under GOPATH so dep etc works
-    echo "Setting up GOPATH to include $PWD"
-    CHECKOUT=$(basename "$PWD")
-    mkdir -p $GODIR
-    ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
-
-    cd "${GODIR}/${CHECKOUT}/test"
-    echo "Running go dep"
-    dep ensure
+  echo "Running all tests"
+  gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128
 fi
-
-echo "Starting tests"
-gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128


### PR DESCRIPTION
Will be tested via `2.x-rc` branch on a few packages before merging to master and releasing on `2.x-stable`.

- **Software Updates**
    - Go image v1.19
    -  gotestsum v1.9.0
    - AWSCLI v2
    - Packer v1.8.5
    - tfenv v1.3.5
    - tf default v1.3.4
- **New Features**
    -  `modified_modules` : List of module names that have been updated. Used to only run tests for modified modules. If not specified all tests run.
- **Changes**
    - Move away from legacy GOPATH / DEP & GO111MODULE defaults to on to make package management easier.

`modified_modules` assumes a consistent directory structure as follows:
```
modules/
    s3-bucket/
        main.tf
examples/
    s3-bucket/
        main.tf
test/
    s3-bucket/
        <any>.go
```

Tested:
- Single module updated and passed as `modified_modules` input. ✅ 
- Multiple modules updated and passed as `modified_modules` input. ✅  
- `modified_modules` not set at package level so all tests still run. ✅ 