### PR TITLE
Add input to only test modified files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
     python3-venv \
     go-dep ;
 
+# Newer git versions don't trust this directory due to the default permissions
+RUN git config --system --add safe.directory /github/workspace
+
 # Install gotestsum for parsing test output
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum
 

--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,8 @@ This action expects the terraform module to use terratest and for the tests to b
 The common workflow is running terratest to test terraform against AWS. The action accepts input paramters:
 
   * **SSH_PRIV_KEY** - SSH private key with clone access to any further private repositories that may be needed
+  * **only_test_modified** - Optional: Set to true if you want to only run tests on modules that have been changed since creating the branch. Note this requires `fetch-depth: 0` to be set on the checkout step.
+  * **target_branch** - Optional: The target branch for PRs, which is compared to for calculating changed modules when the above option is enabled.
 
 For authentication with AWS you can set the environment variables:
 
@@ -33,11 +35,12 @@ jobs:
       - name: checkout step
         uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: test execution step
         uses: fac/terratest-github-action@master
         with:
           SSH_PRIV_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          only_test_modified: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,9 @@ inputs:
   SSH_PRIV_KEY:
     description: "Private SSH key with access to private repos that tests will need access to"
     required: true
-  extra_terratest_args:
-    description: "Extra arguments to provide to terratest."
+  only_test_modified:
+    description: "Whether to test only the modified modules. This assumes your test functions are prefixed TestModuleName, and will run all tests for any _test.go files changed. Changes are calculated with git diff origin/HEAD, and requires the checkout action to clone the full repo."
+    type: boolean
   terraform_version:
     description: "If set override any .terraform-version file in the repo and use this specific version (can be latest)"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   only_test_modified:
     description: "Whether to test only the modified modules. This assumes your test functions are prefixed TestModuleName, and will run all tests for any _test.go files changed. Changes are calculated with git diff origin/HEAD, and requires the checkout action to clone the full repo."
     type: boolean
+  target_branch:
+    description: "The target branch for which to calculate changesets to be tested. Defaults to master."
+    type: string
   terraform_version:
     description: "If set override any .terraform-version file in the repo and use this specific version (can be latest)"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
   SSH_PRIV_KEY:
     description: "Private SSH key with access to private repos that tests will need access to"
     required: true
+  extra_terratest_args:
+    description: "Extra arguments to provide to terratest."
   terraform_version:
     description: "If set override any .terraform-version file in the repo and use this specific version (can be latest)"
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ else
 fi
 
 if $INPUT_ONLY_TEST_MODIFIED; then
-  git_diff="$(git diff --name-only origin/HEAD)" 
+  git_diff="$(git diff --name-only origin/HEAD...)" 
   tests_to_run=$(python -c 'import sys, re; from pathlib import Path
 for input_line in sys.stdin:
   filename = input_line.rstrip()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,7 @@ else
 fi
 
 if $INPUT_ONLY_TEST_MODIFIED; then
+  git_diff="$(git diff --name-only origin/HEAD)" 
   tests_to_run=$(python -c 'import sys, re; from pathlib import Path
 for input_line in sys.stdin:
   filename = input_line.rstrip()
@@ -54,7 +55,7 @@ for input_line in sys.stdin:
     with open(filename, "r") as file:
       for line in file:
         if re.search(r"func Test[A-Z]", line):
-          print(f"-run {line.split()[1]}")' <<< "$(git diff --name-only origin/HEAD)" | sort -u)
+          print(f"-run {line.split()[1]}")' <<< "$git_diff" | sort -u)
   if [ -z "$tests_to_run" ]; then
     echo "No tests to run"
     exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,17 +49,15 @@ for input_line in sys.stdin:
   if filename.endswith(".tf"):
     module_name = Path(filename).parent.name
     test_name = module_name.title().replace("-", "")
-    print(f"Test{test_name}")
+    print(f"-run Test{test_name}")
   elif filename.endswith("_test.go"):
     with open(filename, "r") as file:
       for line in file:
         if re.search(r"func Test[A-Z]", line):
-          print(line.split()[1])' <<< "$(git diff --name-only origin/HEAD)" | sort -u)
+          print(f"-run {line.split()[1]}")' <<< "$(git diff --name-only origin/HEAD)" | sort -u)
   if [ -z "$tests_to_run" ]; then
     echo "No tests to run"
     exit 0
-  else
-    tests_argument="-run $tests_to_run"
   fi
 fi
 
@@ -68,4 +66,4 @@ fi
 
 echo "Starting tests"
 # shellcheck disable=SC2086
-gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128 $tests_argument
+gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128 $tests_to_run

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,8 @@ if [ "$INPUT_ONLY_TEST_MODIFIED" == "true" ]; then
     INPUT_TARGET_BRANCH="master"
   fi
   git_diff="$(git diff --name-only "origin/$INPUT_TARGET_BRANCH...")"
-  tests_to_run=$(python -c 'import sys, re; from pathlib import Path
+  tests_to_run=$(python3 -c '
+import sys, re; from pathlib import Path
 for input_line in sys.stdin:
   filename = input_line.rstrip()
   if filename.endswith(".tf"):
@@ -58,7 +59,8 @@ for input_line in sys.stdin:
     with open(filename, "r") as file:
       for line in file:
         if re.search(r"func Test[A-Z]", line):
-          print(f"-run {line.split()[1]}")' <<< "$git_diff" | sort -u)
+          print(f"-run {line.split()[1]}")
+' <<< "$git_diff" | sort -u)
   if [ -z "$tests_to_run" ]; then
     echo "No tests to run"
     exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,8 +42,11 @@ else
     dep ensure
 fi
 
-if $INPUT_ONLY_TEST_MODIFIED; then
-  git_diff="$(git diff --name-only origin/HEAD...)" 
+if [ "$INPUT_ONLY_TEST_MODIFIED" == "true" ]; then
+  if [ -z "$INPUT_TARGET_BRANCH" ]; then
+    INPUT_TARGET_BRANCH="master"
+  fi
+  git_diff="$(git diff --name-only "origin/$INPUT_TARGET_BRANCH...")"
   tests_to_run=$(python -c 'import sys, re; from pathlib import Path
 for input_line in sys.stdin:
   filename = input_line.rstrip()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,21 +27,6 @@ else
   tfenv install || true
 fi
 
-if [ -f "$PWD/test/go.mod" ]; then
-    echo "Detected go.mod in test directory. Using that for dependencies."
-    cd "$PWD/test"
-else
-    # Setup under GOPATH so dep etc works
-    echo "Setting up GOPATH to include $PWD"
-    CHECKOUT=$(basename "$PWD")
-    mkdir -p $GODIR
-    ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
-
-    cd "${GODIR}/${CHECKOUT}/test"
-    echo "Running go dep"
-    dep ensure
-fi
-
 if [ "$INPUT_ONLY_TEST_MODIFIED" == "true" ]; then
   if [ -z "$INPUT_TARGET_BRANCH" ]; then
     INPUT_TARGET_BRANCH="master"
@@ -67,8 +52,20 @@ for input_line in sys.stdin:
   fi
 fi
 
+if [ -f "$PWD/test/go.mod" ]; then
+    echo "Detected go.mod in test directory. Using that for dependencies."
+    cd "$PWD/test"
+else
+    # Setup under GOPATH so dep etc works
+    echo "Setting up GOPATH to include $PWD"
+    CHECKOUT=$(basename "$PWD")
+    mkdir -p $GODIR
+    ln -s "$(pwd)" "${GODIR}/${CHECKOUT}"
 
-
+    cd "${GODIR}/${CHECKOUT}/test"
+    echo "Running go dep"
+    dep ensure
+fi
 
 echo "Starting tests"
 # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,4 +43,5 @@ else
 fi
 
 echo "Starting tests"
-gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128
+# shellcheck disable=SC2086
+gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128 $INPUT_EXTRA_TERRATEST_ARGS 


### PR DESCRIPTION
This adds two extra inputs, `only_test_modified` and `target_branch`. The first is a boolean, which tells the action to only run tests for modules that have changed when compared to `target_branch` (defaults to `master`). This is calculated based on the directory that `.tf` files have changed in and assuming that directory is converted to camel case and tested with a function beginning with `TestModuleName`. Multiple test functions can be defined with `TestModuleName_moretests`. This naming scheme basically matches the terraform/terraform-provider-aws test naming scheme, and [Go more generally](https://pkg.go.dev/testing#pkg-overview)

This will also run all tests in a file if a file ending in `_test.go` file has changed.

This behaviour is disabled by default for backwards-compatibility.

Note, I've needed to add some git config into the image due to git returning the following error when trying to run in the container:
```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```