### PR TITLE
Make the 50m timeout an input so it can be changed.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
     required: true
   terraform_version:
     description: "If set override any .terraform-version file in the repo and use this specific version (can be latest)"
+  timeout:
+    description: "Timeout before cancelling the tests. Defaults to 50m."
+    default: "50m"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,4 +43,4 @@ else
 fi
 
 echo "Starting tests"
-gotestsum --format standard-verbose -- -v -timeout 50m -parallel 128
+gotestsum --format standard-verbose -- -v -timeout "$INPUT_TIMEOUT" -parallel 128


### PR DESCRIPTION
This failed on our monthly CI for testing data-storage modules against the new TF version.

Have tested it works as expected here: https://github.com/fac/package-data-storage/actions/runs/6377190355/job/17305393947 NB it doesn't explicitly say the value's passed in properly, but does confirm the environment variable is the correct one.