### PR TITLE
Terratest update dependency - Go update 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-buster
+FROM golang:1.21-buster
 
 # As of v1.16 module-aware mode is enabled by default, regardless of whether a go.mod file is present in the current working directory or a parent directory.
 # More precisely, the GO111MODULE environment variable now defaults to on.


### PR DESCRIPTION
Refer to: https://github.com/fac/platform-issues/issues/2951

Required change: https://github.com/gruntwork-io/terratest/releases/tag/v0.44.0